### PR TITLE
feat: prune expired rate limiters and fix concurrency bugs

### DIFF
--- a/cmd/web/middleware/rate_limiting.go
+++ b/cmd/web/middleware/rate_limiting.go
@@ -1,63 +1,119 @@
 package middleware
 
 import (
-	"log"
 	"net"
 	"net/http"
 	"sync"
+	"sync/atomic"
 	"time"
 
-	"pet-everyone/cmd/web/application"
-
 	"golang.org/x/time/rate"
+	"pet-everyone/cmd/web/application"
 )
 
-// clientLimiter is a store of a client's rate limiter and the time they were last seen
+const (
+	DefaultLimiterTTL    = 30 * time.Minute
+	DefaultPruneInterval = 5 * time.Minute
+)
+
+// clientLimiter is a store of a client's rate limiter and the time they were last seen.
+// lastSeen is stored as unix nanos in an atomic so the request hot path can update it
+// without taking rateLimiterMap's write lock.
 type clientLimiter struct {
 	ip       string
 	limiter  *rate.Limiter
-	lastSeen time.Time
+	lastSeen atomic.Int64
 }
 
-// TODO: switch to map[string]*clientLimiter so we can use lastSeen for pruning
+// touch records the last time this client was seen.
+func (c *clientLimiter) touch(t time.Time) {
+	c.lastSeen.Store(t.UnixNano())
+}
+
 type rateLimiterMap struct {
-	ipLimiterMap map[string]*rate.Limiter
-	mu           sync.RWMutex
+	ipLimiterMap  map[string]*clientLimiter
+	mu            sync.RWMutex
+	limiterTTL    time.Duration
+	pruneInterval time.Duration
 }
 
 // prune iterates through active limiters and prunes TTL expired entries
 func (r *rateLimiterMap) prune() {
-	var interval time.Duration
-	ticker := time.NewTicker(interval)
-	for {
-		select {
-		case t := <-ticker.C:
-			log.Println("Pruning rate limiter map at", t)
+	ticker := time.NewTicker(r.pruneInterval)
+	defer ticker.Stop()
+
+	for range ticker.C {
+		now := time.Now()
+
+		r.mu.Lock()
+		for ip, lim := range r.ipLimiterMap {
+			lastSeen := time.Unix(0, lim.lastSeen.Load())
+			if now.After(lastSeen.Add(r.limiterTTL)) {
+				delete(r.ipLimiterMap, ip)
+			}
 		}
+		r.mu.Unlock()
 	}
+}
+
+// getClient returns the limiter for ip, creating it if absent, and records the
+// client as just seen. Creation is double-checked under the write lock so that
+// concurrent first-requests from the same IP share a single limiter.
+func (r *rateLimiterMap) getClient(ip string, l rate.Limit, burst int) *clientLimiter {
+	now := time.Now()
+
+	r.mu.RLock()
+	client, exists := r.ipLimiterMap[ip]
+	r.mu.RUnlock()
+
+	if exists {
+		client.touch(now)
+		return client
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// Another goroutine may have created the client between releasing the read
+	// lock and acquiring the write lock.
+	if client, exists = r.ipLimiterMap[ip]; exists {
+		client.touch(now)
+		return client
+	}
+
+	client = &clientLimiter{
+		ip:      ip,
+		limiter: rate.NewLimiter(l, burst),
+	}
+	client.touch(now)
+	r.ipLimiterMap[ip] = client
+
+	return client
 }
 
 func RateLimit(app *application.Config, interval time.Duration, burst int) func(http.Handler) http.Handler {
 	rlm := rateLimiterMap{
-		ipLimiterMap: make(map[string]*rate.Limiter),
+		ipLimiterMap:  make(map[string]*clientLimiter),
+		limiterTTL:    DefaultLimiterTTL,
+		pruneInterval: DefaultPruneInterval,
 	}
 
 	l := rate.Every(interval)
 
+	go rlm.prune()
+
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			ip := getIP(r)
+			ip, err := getIP(r)
 
-			rlm.mu.RLock()
-			limiter, exists := rlm.ipLimiterMap[ip]
-
-			if !exists {
-				limiter = rate.NewLimiter(l, burst)
-				rlm.ipLimiterMap[ip] = limiter
+			if err != nil {
+				app.RespondWithError(w, http.StatusInternalServerError, "An unknown error occurred", nil)
+				return
 			}
-			rlm.mu.RUnlock()
 
-			if !limiter.Allow() {
+			client := rlm.getClient(ip, l, burst)
+
+			if !client.limiter.Allow() {
 				app.RespondWithError(w, http.StatusTooManyRequests, "Too many requests", nil)
 				return
 			}
@@ -67,11 +123,10 @@ func RateLimit(app *application.Config, interval time.Duration, burst int) func(
 	}
 }
 
-func getIP(r *http.Request) string {
+func getIP(r *http.Request) (string, error) {
 	host, _, err := net.SplitHostPort(r.RemoteAddr)
 	if err != nil {
-		log.Println(err)
-		return ""
+		return "", err
 	}
-	return host
+	return host, nil
 }

--- a/cmd/web/middleware/rate_limiting_test.go
+++ b/cmd/web/middleware/rate_limiting_test.go
@@ -1,0 +1,53 @@
+package middleware
+
+import (
+	"testing"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+func testLimiterMap(t *testing.T) *rateLimiterMap {
+	t.Helper()
+	return &rateLimiterMap{
+		ipLimiterMap:  make(map[string]*clientLimiter),
+		limiterTTL:    1 * time.Millisecond,
+		pruneInterval: 2 * time.Millisecond,
+	}
+
+}
+
+func Test_RateLimitPrune(t *testing.T) {
+	rlm := testLimiterMap(t)
+
+	expired := &clientLimiter{
+		ip:      "0.0.0.0",
+		limiter: rate.NewLimiter(rate.Every(1*time.Minute), 15),
+	}
+	expired.touch(time.Now())
+
+	safe := &clientLimiter{
+		ip:      "0.0.0.1",
+		limiter: rate.NewLimiter(rate.Every(1*time.Minute), 15),
+	}
+	safe.touch(time.Now().Add(5 * time.Minute))
+
+	rlm.ipLimiterMap[expired.ip] = expired
+	rlm.ipLimiterMap[safe.ip] = safe
+
+	go rlm.prune()
+
+	delay := time.NewTicker(5 * time.Millisecond)
+	<-delay.C
+
+	rlm.mu.RLock()
+	defer rlm.mu.RUnlock()
+
+	if _, ok := rlm.ipLimiterMap[expired.ip]; ok {
+		t.Fatalf("Expected client1 to be pruned, was not")
+	}
+
+	if _, ok := rlm.ipLimiterMap[safe.ip]; !ok {
+		t.Fatalf("Expected client2 to be present, was pruned")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/jackc/pgx/v5 v5.7.6
 	github.com/joho/godotenv v1.5.1
 	github.com/redis/go-redis/v9 v9.17.2
+	golang.org/x/time v0.14.0
 )
 
 require (
@@ -22,5 +23,4 @@ require (
 	golang.org/x/sync v0.17.0 // indirect
 	golang.org/x/sys v0.32.0 // indirect
 	golang.org/x/text v0.30.0 // indirect
-	golang.org/x/time v0.14.0 // indirect
 )


### PR DESCRIPTION
Implement the previously-stubbed prune goroutine to evict limiters idle past the TTL, and make the limiter map safe under concurrency:

- store lastSeen as an atomic so the request hot path updates it without the write lock
- get-or-create limiters via double-checked locking so concurrent first-requests from one IP share a single limiter
- return an error from getIP instead of silently using ""

Add a race-clean test for prune.